### PR TITLE
Fix warnings in test suite

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -39,7 +39,7 @@ get_timestep <- function(aPer) {
   if(aPer > 1){
     yrs <- YEARS[[aPer]] - YEARS[[aPer - 1]]
   } else{
-    print("ERROR: Invalid period passed to get_timestep")
+    stop("Invalid period passed to get_timestep")
   }
 
   return(yrs)

--- a/R/main.R
+++ b/R/main.R
@@ -93,7 +93,7 @@ run_ensembles <- function(aOutputDir = "./outputs") {
 
   # Loop over all scenario configurations and run the model
   foreach(obj = scenObjects) %dopar% {
-    print(paste0("Starting simulation: ", obj$mFileName))
+    message("Starting simulation: ", obj$mFileName)
     run_model(obj)
   }
 }
@@ -113,7 +113,7 @@ run_model <- function(aScenarioInfo) {
   # Loop through each period and run the model
   # TODO: put model running in a function, add loop on regions
   for(per in PERIODS){
-    print(paste("Starting period:", per))
+    message("Starting period: ", per)
 
     # First, call initCalc for AgProductionTechnology (via Sector) and LandAllocator
     # Note: AgProductionTechnology must be called first so profits
@@ -126,12 +126,12 @@ run_model <- function(aScenarioInfo) {
   }
 
   # Print Outputs
-  print("All model periods complete. Starting output.")
+  message("All model periods complete. Starting output.")
   printOutput(mLandAllocator, aScenarioInfo)
 
   # Make figures
   if(MAKE.PLOTS) {
-    print("Plotting diagnostic figures.")
+    message("Plotting diagnostic figures.")
     plotNest(mLandAllocator, aScenarioInfo)
     plotLandAllocation(mLandAllocator, aScenarioInfo)
     plotRegionalLandAllocation(mLandAllocator, aScenarioInfo)

--- a/R/plot_land.R
+++ b/R/plot_land.R
@@ -45,6 +45,11 @@ plotLandAllocation <- function(aLandAllocator, aScenarioInfo) {
 
   # Now, plot land allocation over time
   p <- ggplot() + geom_area(data = allLand, aes(year, land.allocation, fill=name))
+
+  ## TODO:  Consider returning the plot instead of printing it.  That gives the user the
+  ##        option of either printing it or saving it for later, as well as providing a
+  ##        useful return value.  (The return value of print.ggplot is probably not
+  ##        useful for most users.)
   print(p)
 }
 
@@ -82,6 +87,8 @@ plotRegionalLandAllocation <- function(aLandAllocator, aScenarioInfo) {
 
   # Now, plot regional land allocation over time
   p <- ggplot() + geom_area(data = regionalLand, aes(year, land.allocation, fill=land.type))
+
+  ## TODO:  return plot instead of printing it.
   print(p)
 }
 

--- a/R/reporting.R
+++ b/R/reporting.R
@@ -24,8 +24,8 @@ printOutput <- function(aLandAllocator, aScenarioInfo) {
 #' @param aScenarioInfo Scenario-related information, including names, logits, expectations
 #' @author KVC November 2017
 printPrices <- function(aScenarioInfo) {
-  file <- paste(aScenarioInfo$aOutputDir, "prices.csv", sep="/")
-  write_csv(PRICES, normalizePath(file))
+  file <- file.path(aScenarioInfo$aOutputDir, "prices.csv")
+  write_csv(PRICES, file)
 }
 
 #' printLandAllocation

--- a/tests/testthat/test_calibration.R
+++ b/tests/testthat/test_calibration.R
@@ -18,12 +18,12 @@ test_that("land cover matches calibration data", {
   }
 
   # Run the model to generate outputs
-  path <- normalizePath(file.path("./outputs/"))
+  path <- "./outputs"
   if(!dir.exists(path)) {
-    dir.create(path, showWarnings = FALSE)
-    dir.create(normalizePath(file.path(paste0(path, "land/"))), showWarnings = FALSE)
-    dir.create(normalizePath(file.path(paste0(path, "expectedYield/"))), showWarnings = FALSE)
-    dir.create(normalizePath(file.path(paste0(path, "expectedPrice/"))), showWarnings = FALSE)
+    dir.create(path)
+    dir.create(file.path(path, "land"))
+    dir.create(file.path(path, "expectedYield"))
+    dir.create(file.path(path, "expectedPrice"))
   }
   run_model(SCENARIO.INFO)
 

--- a/tests/testthat/test_expectations.R
+++ b/tests/testthat/test_expectations.R
@@ -57,7 +57,7 @@ test_that("yield expectation calculation works", {
   # Next, create a temp scenarioInfo object with the right parameters
   tempScen <- ScenarioInfo()
   tempScen$mLaggedShareOld <- 0.5
-  tempScen$mLinearYears <- 1
+  tempScen$mLinearYears <- 2
 
   # Now, calculate expectations using all methods
   perfectYield <- PerfectExpectation_calcExpectedYield(testLeaf, 4)


### PR DESCRIPTION
Changes:
* Eliminate calls to `normalizePath()`.  This function throws a warning when the file named by its argument doesn't exist.  The warning can be suppressed, but in such cases the function doesn't actually do anything (it returns its argument unmodified).  Fortunately, it is rarely necessary to call this function, if all you want to do is access the file.
* Run the test of `LinearExpectation_calcExpectedYield()` using two regression periods instead of one.  This eliminated a warning being thrown by `predict.lm`.
* Write status messages using `message` instead of `print` (except for one that was actually reporting an unrecoverable error, which was changed to use `stop`.)  This wasn't strictly a warning fix, but it cleans up the test log a bit, and it's considered best practice.  (See, for example, https://stackoverflow.com/a/36700294)