### PR TITLE
Ensure that output and log directories exist when running parallel jobs.

### DIFF
--- a/inst/scripts/jobrun.zsh
+++ b/inst/scripts/jobrun.zsh
@@ -17,6 +17,10 @@ N=96
 outdir="/pic/scratch/$USER/gcamland/output"
 logdir="/pic/scratch/$USER/gcamland"
 
+mkdir -p $outdir
+mkdir -p $logdir
+
+echo "Run command:"
 echo "source('$program'); run_mc('$nodefile', $SLURM_NTASKS, $N, '$outdir', '$logdir')"
 
 Rscript -e "source('$program'); run_mc('$nodefile', $SLURM_NTASKS, $N, '$outdir')"


### PR DESCRIPTION
Small change to the job batch script.  No change to package code.
