### PR TITLE
Update examples for run_model

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gcamland
 Type: Package
 Title: GCAM Land Allocation Module
-Version: 1.0.1
+Version: 1.0.2
 Author: Katherine Calvin
 Maintainer: Katherine Calvin <katherine.calvin@pnnl.gov>
 Description: Allocates land among a variety of uses following the methodology in GCAM (github.com/jgcri/gcam-core).

--- a/R/gcamland.R
+++ b/R/gcamland.R
@@ -15,8 +15,8 @@
 #' scenario parameters. The scenario structure can be passed directly to the
 #' main model function.  Then the model can be run with the
 #' \code{\link{run_model}} function.
-#' \code{
-#' sceninfo <- ScenarioInfo(aScenarioType = "Hindcast", aOutputDir = "./output")
+#' \preformatted{
+#' sceninfo <- ScenarioInfo(aExpectationType = "Perfect", aScenarioType = "Hindcast", aScenarioName = "Perfect_Hindcast", aFileName = "Perfect_Hindcast")
 #' rslt <- run_model(sceninfo)
 #' }
 #' The results will be returned as a data frame.  If the \code{aVerbose}

--- a/R/main.R
+++ b/R/main.R
@@ -231,6 +231,9 @@ gen_ensemble_member <- function(agFor, agForNonPast, crop, share, linyears,
 #' @return Table of model results.
 #' @author KVC
 #' @export
+#' @examples
+#' run_model(SCENARIO.INFO, aVerbose=TRUE)
+#' run_model(SCENARIO.INFO, aPeriods = 1:5)
 run_model <- function(aScenarioInfo, aPeriods=NULL, aVerbose=FALSE) {
   #### Step 1: Setup
   # Ensure that output directories exist

--- a/R/main.R
+++ b/R/main.R
@@ -224,7 +224,9 @@ gen_ensemble_member <- function(agFor, agForNonPast, crop, share, linyears,
 #'
 #' Loop through all years and run the land model.
 #'
-#' @param aScenarioInfo Scenario-related information, including names, logits, expectations.
+#' @param aScenarioInfo A structure containing scenario-related information,
+#' created by \code{\link{ScenarioInfo}}.  There is a pre-built structure for the
+#' default scenario called \code{\link{SCENARIO.INFO}}.
 #' @param aPeriods Integer vector of periods to run.  Default is all periods
 #' defined for the scenario type.
 #' @param aVerbose If \code{TRUE}, output additional debugging information.

--- a/R/main.R
+++ b/R/main.R
@@ -232,8 +232,10 @@ gen_ensemble_member <- function(agFor, agForNonPast, crop, share, linyears,
 #' @author KVC
 #' @export
 #' @examples
+#' \dontrun{
 #' run_model(SCENARIO.INFO, aVerbose=TRUE)
 #' run_model(SCENARIO.INFO, aPeriods = 1:5)
+#' }
 run_model <- function(aScenarioInfo, aPeriods=NULL, aVerbose=FALSE) {
   #### Step 1: Setup
   # Ensure that output directories exist

--- a/man/gcamland.Rd
+++ b/man/gcamland.Rd
@@ -22,8 +22,8 @@ To run an individual scenario, first generate a structure to hold the
 scenario parameters. The scenario structure can be passed directly to the
 main model function.  Then the model can be run with the
 \code{\link{run_model}} function.
-\code{
-sceninfo <- ScenarioInfo(aScenarioType = "Hindcast", aOutputDir = "./output")
+\preformatted{
+sceninfo <- ScenarioInfo(aExpectationType = "Perfect", aScenarioType = "Hindcast", aScenarioName = "Perfect_Hindcast", aFileName = "Perfect_Hindcast")
 rslt <- run_model(sceninfo)
 }
 The results will be returned as a data frame.  If the \code{aVerbose}

--- a/man/run_model.Rd
+++ b/man/run_model.Rd
@@ -7,7 +7,9 @@
 run_model(aScenarioInfo, aPeriods = NULL, aVerbose = FALSE)
 }
 \arguments{
-\item{aScenarioInfo}{Scenario-related information, including names, logits, expectations.}
+\item{aScenarioInfo}{A structure containing scenario-related information,
+created by \code{\link{ScenarioInfo}}.  There is a pre-built structure for the
+default scenario called \code{\link{SCENARIO.INFO}}.}
 
 \item{aPeriods}{Integer vector of periods to run.  Default is all periods
 defined for the scenario type.}

--- a/man/run_model.Rd
+++ b/man/run_model.Rd
@@ -20,6 +20,10 @@ Table of model results.
 \description{
 Loop through all years and run the land model.
 }
+\examples{
+run_model(SCENARIO.INFO, aVerbose=TRUE)
+run_model(SCENARIO.INFO, aPeriods = 1:5)
+}
 \author{
 KVC
 }

--- a/man/run_model.Rd
+++ b/man/run_model.Rd
@@ -21,8 +21,10 @@ Table of model results.
 Loop through all years and run the land model.
 }
 \examples{
+\dontrun{
 run_model(SCENARIO.INFO, aVerbose=TRUE)
 run_model(SCENARIO.INFO, aPeriods = 1:5)
+}
 }
 \author{
 KVC


### PR DESCRIPTION
This updates the examples to ones that will run, addressing issue: https://github.com/JGCRI/gcamland/issues/38

Note: we currently don't have a default expectation type, scenario name, or file name for ScenarioInfo objects, so these all need to be specified. 