### PR TITLE
Speed up

### DIFF
--- a/R/linear_expectation.R
+++ b/R/linear_expectation.R
@@ -86,11 +86,8 @@ LinearExpectation_calcExpectedPrice <- function(aLandLeaf, aPeriod, aScenarioInf
     yr <- get_per_to_yr(per, aScenarioInfo$mScenarioType)
     price_table <- PRICES[[aScenarioInfo$mScenarioType]]
     if(aLandLeaf$mProductName[1] %in% unique(price_table$sector)) {
-      price_table %>%
-        filter(year == yr, sector == aLandLeaf$mProductName[1]) ->
-        curr.price
-
-      all.prices$price[all.prices$year == i] <- curr.price[[c("price")]]
+      all.prices$price[all.prices$year == i] <- price_table$price[price_table$year == yr &
+                                                                    price_table$sector == aLandLeaf$mProductName[1]]
     } else {
       # TODO: Figure out what to do if price is missing.
       all.prices$price[all.prices$year == i] <- 1

--- a/R/setup.R
+++ b/R/setup.R
@@ -416,8 +416,10 @@ AgProductionTechnology_setup <- function(aLandLeaf, aAgData, aScenarioInfo) {
     }
 
     # Set cost in the LandLeaf
-    if(aScenarioInfo$mUseZeroCost == FALSE & name %in% unique(cost$AgProductionTechnology))  {
-      aLandLeaf$mCost[per] <- as.numeric(cost$nonLandVariableCost[cost$year == y & cost$AgProductionTechnology == name])
+    if(aScenarioInfo$mUseZeroCost == FALSE &
+       name %in% unique(cost$AgProductionTechnology) & y %in% unique(cost$year))  {
+      aLandLeaf$mCost[per] <- as.numeric(cost$nonLandVariableCost[cost$year == y &
+                                                                    cost$AgProductionTechnology == name])
     } else {
       aLandLeaf$mCost[per] <- 0
     }

--- a/man/ScenarioInfo.Rd
+++ b/man/ScenarioInfo.Rd
@@ -32,7 +32,8 @@ FALSE)}
 
 \item{aCalibrateShareWt}{Boolean indicating that the model should calculate share weights during calibration}
 
-\item{aShareWeights}{Share weights to use instead of calibrating}
+\item{aShareWeights}{Named vector of share weights to use instead of calibrating.
+The names should correspond to the names of the land leaf nodes.}
 
 \item{aScenarioType}{Type of scenario to run: either "Reference" or "Hindcast".}
 


### PR DESCRIPTION
Removing most calls to `filter` in the `calcExpectedPrice` and setup methods. 

Reduces runtime for a 10-year linear expectation future simulation from 250s to 90s.