### PR TITLE
Adjust logit bounds and update harvest to cropped ratio

### DIFF
--- a/R/main.R
+++ b/R/main.R
@@ -49,11 +49,11 @@ run_ensemble <- function(N = 500, aOutputDir = "./outputs", skip = 0,
 
   ## Set options for ensembles
   ## min and max values for each parameter
-  limits.AGROFOREST <- c(0.1, 6)
-  limits.AGROFOREST_NONPASTURE <- c(0.1, 6)
-  limits.CROPLAND <- c(0.1, 6)
-  limits.LAGSHARE <- c(0.1, 0.9)
-  limits.LINYEARS <- round(c(2, 20))
+  limits.AGROFOREST <- c(0.001, 3)
+  limits.AGROFOREST_NONPASTURE <- c(0.001, 2)
+  limits.CROPLAND <- c(0.001, 2)
+  limits.LAGSHARE <- c(0.5, 0.99)
+  limits.LINYEARS <- round(c(10, 20))
 
   serialnumber <- skip + (1:N)
   rn <- randtoolbox::sobol(N+skip, NPARAM)

--- a/R/main.R
+++ b/R/main.R
@@ -213,7 +213,7 @@ gen_ensemble_member <- function(agFor, agForNonPast, crop, share, linyears,
                           aLogitCropland = crop,
                           aScenarioName = scenName,
                           aFileName = paste0("ensemble", suffix),
-                          aSerialNum = serialnum+0.2,
+                          aSerialNum = serialnum+0.3,
                           aOutputDir = aOutputDir)
 
   ## Linear scenario
@@ -228,7 +228,7 @@ gen_ensemble_member <- function(agFor, agForNonPast, crop, share, linyears,
                           aLogitCropland = crop,
                           aScenarioName = scenName,
                           aFileName = paste0("ensemble", suffix),
-                          aSerialNum = serialnum+0.3,
+                          aSerialNum = serialnum+0.4,
                           aOutputDir = aOutputDir)
 
   list(perfscen, lagscen, lagcurrscen, linscen)

--- a/R/main.R
+++ b/R/main.R
@@ -49,9 +49,9 @@ run_ensemble <- function(N = 500, aOutputDir = "./outputs", skip = 0,
 
   ## Set options for ensembles
   ## min and max values for each parameter
-  limits.AGROFOREST <- c(0.001, 3)
-  limits.AGROFOREST_NONPASTURE <- c(0.001, 2)
-  limits.CROPLAND <- c(0.001, 2)
+  limits.AGROFOREST <- c(0.1, 3)
+  limits.AGROFOREST_NONPASTURE <- c(0.1, 2)
+  limits.CROPLAND <- c(0.1, 2)
   limits.LAGSHARE <- c(0.5, 0.99)
   limits.LINYEARS <- round(c(10, 20))
 

--- a/R/setup.R
+++ b/R/setup.R
@@ -433,15 +433,15 @@ AgProductionTechnology_setup <- function(aLandLeaf, aAgData, aScenarioInfo) {
     }
 
     # Set harvested to cropped ratio in the LandLeaf
-    if(name %in% HAtoCL$AgProductionTechnology & y %in% HAtoCL$year)  {
-      aLandLeaf$mHAtoCL[per] <- as.numeric(HAtoCL$harvests.per.year[HAtoCL$year == y &
-                                                                        HAtoCL$AgProductionTechnology == name])
-    } else if (name %in% HAtoCL$AgProductionTechnology & aScenarioInfo$mScenarioType == "Hindcast") {
+    if (name %in% HAtoCL$AgProductionTechnology & aScenarioInfo$mScenarioType == "Hindcast") {
       # Note we only have data for model periods defined in the reference. For Hindcasts, we should
       # use 1975 values for all periods.
       aLandLeaf$mHAtoCL[per] <- as.numeric(HAtoCL$harvests.per.year[HAtoCL$year == min(YEARS[[aScenarioInfo$mScenarioType]]) &
                                                                       HAtoCL$AgProductionTechnology == name])
-    } else {
+    } else if(name %in% HAtoCL$AgProductionTechnology & y %in% HAtoCL$year)  {
+       aLandLeaf$mHAtoCL[per] <- as.numeric(HAtoCL$harvests.per.year[HAtoCL$year == y &
+                                                                       HAtoCL$AgProductionTechnology == name])
+     } else {
       aLandLeaf$mHAtoCL[per] <- 1
     }
 


### PR DESCRIPTION
Narrow the logit bounds based on results of earlier ensembles. Also, ensure that the harvest to cropped ratio is constant in hindcast simulations